### PR TITLE
please just remove the reference to MVC.

### DIFF
--- a/framework-variables/main.md
+++ b/framework-variables/main.md
@@ -2,7 +2,7 @@
 
 ## Basic Use
 
-Variables defined in Fat-Free are global, i.e. they can be accessed by any MVC component. Framework globals are not identical to PHP globals. An F3 variable named `content` is not identical to PHP's `$content`. F3 is a domain-specific language in its own right and maintains its own separate symbol table for system and application variables. The framework, like every well-designed object-oriented program, does not pollute the PHP global namespace with constants, variables, functions or classes that might conflict with any application. Unlike other frameworks, F3 does not use PHP's `define()` statement. All framework constants are confined to classes.
+Variables defined in Fat-Free are global, i.e. they can be accessed by any component. Framework globals are not identical to PHP globals. An F3 variable named `content` is not identical to PHP's `$content`. F3 is a domain-specific language in its own right and maintains its own separate symbol table for system and application variables. The framework, like every well-designed object-oriented program, does not pollute the PHP global namespace with constants, variables, functions or classes that might conflict with any application. Unlike other frameworks, F3 does not use PHP's `define()` statement. All framework constants are confined to classes.
 
 To assign a value to a Fat-Free variable:
 


### PR DESCRIPTION
F3 is not an MVC framework. It CAN be but it also can be anything else you want it to be. By using the MVC term in that sentence makes it seem F3 is an MVC framework only.
