### PR TITLE
update main.md

### DIFF
--- a/3.6/routing-engine/main.md
+++ b/3.6/routing-engine/main.md
@@ -31,7 +31,6 @@ HTTP requests can also be routed to static class methods:
 ```php
 $f3->route('GET /login','Controller\Auth::login');
 ```
-
 <div class="alert alert-info">Stuck with a <strong>404 Not Found</strong> error? Check your <a href="routing-engine#sample-apache-configuration">server configuration</a>.</div>
 
 ## Routes and Tokens


### PR DESCRIPTION
HTTP requests can also be routed to static class methods:

```php
$f3->route('GET /login','Controller\Auth::login');
```

The example is Wrong, we receive the message 

Internal Server Error
Non-static method Auth::login() should not be called statically