### PR TITLE
Updatd documentation that contained small meritorical error

### DIFF
--- a/3.6/views-and-templates/main.md
+++ b/3.6/views-and-templates/main.md
@@ -14,7 +14,7 @@ F3 supports PHP as a template engine. Take a look at this HTML fragment saved as
 <p>Hello, <?php echo $name; ?>!</p>
 ```
 
-If short tags are enabled on your server, this should work too:
+Regardless, if short tags are enabled on your server or not, this should work too:
 
 ``` html
 <p>Hello, <?= $name ?></p>


### PR DESCRIPTION
PHP allways supports `<?=` tag. Short tags are `<?` instead of `<?php`

Please see PHP 5.4.0 changelog or please see this link: https://www.php.net/manual/en/language.basic-syntax.phptags.php

Since F3 requires PHP 5.4 (I think we all should move to PHP 7.X) this is correct for all F3 instances, since no instance should run on PHP below 5.4
