### PR TITLE
Update main.md

### DIFF
--- a/3.6/mongo-mapper/main.md
+++ b/3.6/mongo-mapper/main.md
@@ -58,7 +58,7 @@ $userList = $user->find(array('email'=> new \MongoRegex('/gmail/')));
 Or just load a single user by its ID:
 
 ```php
-$user->load(array('_id'=> new \MongoId('507c35dd8fada716c89d0013')));
+$user->load(array('_id'=> new \MongoDB\BSON\ObjectID('507c35dd8fada716c89d0013')));
 ```
 
 ### $option


### PR DESCRIPTION
Load by ID. Because of support to new Mongodb drive $user->load(array('_id' => new \MongoId('50ecaa466afa2f8c1c000004'))); doesn't work.
$user->load(array('_id'=> new \MongoDB\BSON\ObjectID('507c35dd8fada716c89d0013'))); is working.