### PR TITLE
Lib update

### DIFF
--- a/3.5/development/main.md
+++ b/3.5/development/main.md
@@ -72,7 +72,7 @@ See what other users have made with F3:
         </tr>
         <tr>
             <td><a href="https://github.com/vijinho/f3-boilerplate" target="_blank">F3 Boilerplate</a></td>
-            <td>A F3 boilerplate MVC website skeleton using [HTML5 Boilerplate](http://html5boilerplate.com/ "HTML5 Boilerplate :: The web's most popular front-end template").<br>It's basically a skeleton web application you can use to learn the Fat-Free Framework and use as a base for your future projects.</td>
+            <td>A F3 boilerplate MVC website skeleton using <a href="http://html5boilerplate.com/" title="HTML5 Boilerplate :: The web's most popular front-end template">HTML5 Boilerplate</a>.<br>It's basically a skeleton web application you can use to learn the Fat-Free Framework and use as a base for your future projects.</td>
             <td><a href="https://github.com/vijinho" target="_blank">Vijay Mahrra</a></td>
         </tr>
         <tr>

--- a/3.5/development/main.md
+++ b/3.5/development/main.md
@@ -59,9 +59,9 @@ See what other users have made with F3:
 <table class="table col-sm-12">
     <thead>
         <tr>
-            <th class="col-sm-2">Plugin Name</th>
-            <th class="col-sm-8">Description</th>
-            <th class="col-sm-2">Author</th>
+            <th width="150">Plugin Name</th>
+            <th>Description</th>
+            <th width="150">Author</th>
         <tr>
     </thead>
     <tbody>
@@ -108,9 +108,9 @@ See what other users have made with F3:
     <table class="table">
         <thead>
             <tr>
-                <th class="col-sm-2">Plugin Name</th>
-                <th class="col-sm-8">Description</th>
-                <th class="col-sm-2">Author</th>
+                <th width="150">Plugin Name</th>
+                <th>Description</th>
+                <th width="150">Author</th>
             <tr>
         </thead>
         <tbody>
@@ -133,9 +133,9 @@ See what other users have made with F3:
 <table class="table">
     <thead>
         <tr>
-            <th class="col-sm-2">Plugin Name</th>
-            <th class="col-sm-8">Description</th>
-            <th class="col-sm-2">Author</th>
+            <th width="150">Plugin Name</th>
+            <th>Description</th>
+            <th width="150">Author</th>
         <tr>
     </thead>
     <tbody>
@@ -192,9 +192,9 @@ See what other users have made with F3:
     <table class="table">
         <thead>
             <tr>
-                <th class="col-sm-2">Plugin Name</th>
-                <th class="col-sm-8">Description</th>
-                <th class="col-sm-2">Author</th>
+                <th width="150">Plugin Name</th>
+                <th>Description</th>
+                <th width="150">Author</th>
             <tr>
         </thead>
         <tbody>
@@ -227,7 +227,7 @@ See what other users have made with F3:
 <table class="table">
 	<colgroup>
 		<col class="col-sm-10">
-		<col class="col-sm-2">
+		<col width="150">
 	</colgroup>
     <thead>
         <tr>

--- a/3.5/user-guide/left.md
+++ b/3.5/user-guide/left.md
@@ -1,4 +1,4 @@
-#### Too much at all?
+#### Too much at once?
 Then just have a look at the<br> [**Quick Reference**](quick-reference).
 
 #### New to F3?

--- a/3.6/development/main.md
+++ b/3.6/development/main.md
@@ -72,7 +72,7 @@ See what other users have made with F3:
         </tr>
         <tr>
             <td><a href="https://github.com/vijinho/f3-boilerplate" target="_blank">F3 Boilerplate</a></td>
-            <td>A F3 boilerplate MVC website skeleton using [HTML5 Boilerplate](http://html5boilerplate.com/ "HTML5 Boilerplate :: The web's most popular front-end template").<br>It's basically a skeleton web application you can use to learn the Fat-Free Framework and use as a base for your future projects.</td>
+            <td>A F3 boilerplate MVC website skeleton using <a href="http://html5boilerplate.com/" title="HTML5 Boilerplate :: The web's most popular front-end template">HTML5 Boilerplate</a>.<br>It's basically a skeleton web application you can use to learn the Fat-Free Framework and use as a base for your future projects.</td>
             <td><a href="https://github.com/vijinho" target="_blank">Vijay Mahrra</a></td>
         </tr>
         <tr>

--- a/3.6/development/main.md
+++ b/3.6/development/main.md
@@ -59,9 +59,9 @@ See what other users have made with F3:
 <table class="table col-sm-12">
     <thead>
         <tr>
-            <th class="col-sm-2">Plugin Name</th>
-            <th class="col-sm-8">Description</th>
-            <th class="col-sm-2">Author</th>
+            <th width="150">Plugin Name</th>
+            <th>Description</th>
+            <th width="150">Author</th>
         <tr>
     </thead>
     <tbody>
@@ -108,9 +108,9 @@ See what other users have made with F3:
     <table class="table">
         <thead>
             <tr>
-                <th class="col-sm-2">Plugin Name</th>
-                <th class="col-sm-8">Description</th>
-                <th class="col-sm-2">Author</th>
+                <th width="150">Plugin Name</th>
+                <th>Description</th>
+                <th width="150">Author</th>
             <tr>
         </thead>
         <tbody>
@@ -133,9 +133,9 @@ See what other users have made with F3:
 <table class="table">
     <thead>
         <tr>
-            <th class="col-sm-2">Plugin Name</th>
-            <th class="col-sm-8">Description</th>
-            <th class="col-sm-2">Author</th>
+            <th width="150">Plugin Name</th>
+            <th>Description</th>
+            <th width="150">Author</th>
         <tr>
     </thead>
     <tbody>
@@ -197,9 +197,9 @@ See what other users have made with F3:
     <table class="table">
         <thead>
             <tr>
-                <th class="col-sm-2">Plugin Name</th>
-                <th class="col-sm-8">Description</th>
-                <th class="col-sm-2">Author</th>
+                <th width="150">Plugin Name</th>
+                <th>Description</th>
+                <th width="150">Author</th>
             <tr>
         </thead>
         <tbody>
@@ -232,7 +232,7 @@ See what other users have made with F3:
 <table class="table">
 	<colgroup>
 		<col class="col-sm-10">
-		<col class="col-sm-2">
+		<col width="150">
 	</colgroup>
     <thead>
         <tr>

--- a/3.6/user-guide/left.md
+++ b/3.6/user-guide/left.md
@@ -1,4 +1,4 @@
-#### Too much at all?
+#### Too much at once?
 Then just have a look at the<br> [**Quick Reference**](quick-reference).
 
 #### New to F3?

--- a/3.7/development/main.md
+++ b/3.7/development/main.md
@@ -72,7 +72,7 @@ See what other users have made with F3:
         </tr>
         <tr>
             <td><a href="https://github.com/vijinho/f3-boilerplate" target="_blank">F3 Boilerplate</a></td>
-            <td>A F3 boilerplate MVC website skeleton using [HTML5 Boilerplate](http://html5boilerplate.com/ "HTML5 Boilerplate :: The web's most popular front-end template").<br>It's basically a skeleton web application you can use to learn the Fat-Free Framework and use as a base for your future projects.</td>
+            <td>A F3 boilerplate MVC website skeleton using <a href="http://html5boilerplate.com/" title="HTML5 Boilerplate :: The web's most popular front-end template">HTML5 Boilerplate</a>.<br>It's basically a skeleton web application you can use to learn the Fat-Free Framework and use as a base for your future projects.</td>
             <td><a href="https://github.com/vijinho" target="_blank">Vijay Mahrra</a></td>
         </tr>
         <tr>

--- a/3.7/development/main.md
+++ b/3.7/development/main.md
@@ -42,7 +42,7 @@ You can help out with bug reports, fixes in the code and of course your own plug
 F3 uses Git for version control. To clone the code repository on GitHub:
 
 ``` bash
-git clone git://git@github.com:bcosca/Fat-Free-Framework.git
+git clone git://git@github.com:bcosca/fatfree-core.git
 ```
 
 If all you want is a zipball, grab it [**here**](https://github.com/bcosca/fatfree/archive/dev.zip).
@@ -59,9 +59,9 @@ See what other users have made with F3:
 <table class="table col-sm-12">
     <thead>
         <tr>
-            <th class="col-sm-2">Plugin Name</th>
-            <th class="col-sm-8">Description</th>
-            <th class="col-sm-2">Author</th>
+            <th width="150">Plugin Name</th>
+            <th>Description</th>
+            <th width="150">Author</th>
         <tr>
     </thead>
     <tbody>
@@ -108,9 +108,9 @@ See what other users have made with F3:
     <table class="table">
         <thead>
             <tr>
-                <th class="col-sm-2">Plugin Name</th>
-                <th class="col-sm-8">Description</th>
-                <th class="col-sm-2">Author</th>
+                <th width="150">Plugin Name</th>
+                <th>Description</th>
+                <th width="150">Author</th>
             <tr>
         </thead>
         <tbody>
@@ -133,9 +133,9 @@ See what other users have made with F3:
 <table class="table">
     <thead>
         <tr>
-            <th class="col-sm-2">Plugin Name</th>
-            <th class="col-sm-8">Description</th>
-            <th class="col-sm-2">Author</th>
+            <th width="150">Plugin Name</th>
+            <th>Description</th>
+            <th width="150">Author</th>
         <tr>
     </thead>
     <tbody>
@@ -197,9 +197,9 @@ See what other users have made with F3:
     <table class="table">
         <thead>
             <tr>
-                <th class="col-sm-2">Plugin Name</th>
-                <th class="col-sm-8">Description</th>
-                <th class="col-sm-2">Author</th>
+                <th width="150">Plugin Name</th>
+                <th>Description</th>
+                <th width="150">Author</th>
             <tr>
         </thead>
         <tbody>

--- a/3.7/user-guide/left.md
+++ b/3.7/user-guide/left.md
@@ -1,4 +1,4 @@
-#### Too much at all?
+#### Too much at once?
 Then just have a look at the<br> [**Quick Reference**](quick-reference).
 
 #### New to F3?


### PR DESCRIPTION
Regarding the documentation site, I felt like we should at least upgrade the JavaScript and CSS libraries as they are 6 years old. So I upgraded Bootstrap 3 -> 4, jQuery 1 -> 3, FontAwesome 4 -> 5, and then some minor updates for tocify and jQuery UI.

I included all the fixes necessary here to transition to the upgraded frameworks. There will also be a pull request for F3com for the necessary changes to make the appearance look and feel consistent. https://github.com/F3Community/F3com/pull/30

The only major modification made in this change is I converted all `class="container"` to `class="container-fluid"` I also upgraded the F3 core library to `3.7.2` from the outdated `3.6.4`